### PR TITLE
Justin/expo keystore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,10 +51,10 @@ android {
 
     signingConfigs {
         create("release") {
-            keyAlias = "resell"
+            keyAlias = secrets.getProperty("KEY_ALIAS")
             keyPassword = secrets.getProperty("KEY_PASS")
             storeFile = file("/../resell-keystore.jks")
-            storePassword = secrets.getProperty("KEY_PASS")
+            storePassword = secrets.getProperty("KEY_STORE_PASS")
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,12 @@ android {
             storeFile = file("/../resell-keystore.jks")
             storePassword = secrets.getProperty("KEY_STORE_PASS")
         }
+        create("release-mock") {
+            keyAlias = secrets.getProperty("KEY_MOCK_ALIAS")
+            keyPassword = secrets.getProperty("KEY_MOCK_PASS")
+            storeFile = file("/../resell-mock-keystore.jks")
+            storePassword = secrets.getProperty("KEY_MOCK_STORE_PASS")
+        }
     }
 
     buildTypes {
@@ -75,6 +81,24 @@ android {
                 "BASE_API_URL", "\"${secrets.getProperty("API_URL_PROD")}\""
             )
         }
+
+        create("releaseMock") {
+            signingConfig = signingConfigs.getByName("release-mock")
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+            buildConfigField(
+                "String",
+                "GOOGLE_AUTH_CLIENT_ID", "\"${secrets.getProperty("GOOGLE_AUTH_CLIENT_ID")}\""
+            )
+            buildConfigField(
+                "String",
+                "BASE_API_URL", "\"${secrets.getProperty("API_URL_PROD")}\""
+            )
+        }
+
         debug {
             buildConfigField(
                 "String",

--- a/app/src/main/java/com/cornellappdev/resell/android/model/login/GoogleAuthRepository.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/model/login/GoogleAuthRepository.kt
@@ -94,6 +94,7 @@ class GoogleAuthRepository @Inject constructor(
                     )
                 }
             } catch (e: ApiException) {
+                Log.e("GoogleAuthRepository", "Google sign in failed", e)
                 e.printStackTrace()
                 onError()
             }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->
<!-- Your title should be able to summarize what changes you’ve made in one sentence. For example: “Exclude staff from the check for follows”. For stacked PRs, please indicate clearly in the title where in the stack you are. For example: “[Eatery Refactor][4/5] Converted all files to MVP model” -->

## Overview

Tweaks around the keystore to allow devs to continue developing right now, and to provide some groundworks for replacing the current keystore with the existing Expo keystore (so that we can release to the Play Store going forward).

## Changes Made

1. Replaces `resell-keystore.kts` with the Expo (not tracked)
2. Adds `resell-mock-keystore.kts` that people can use to just develop with some mock release keystore (not tracked)
3. Edits `secrets.properties` to add fields for the new keystore (not tracked)
4. Adds a new `releaseMock` build config that runs on the mock release keystore. Allows running / testing on prod even though this build cannot technically release to play store (because it's under a different keystore).

^ Making a slack post to resell android to cover this.

## Test Coverage

Can now log in (whereas on `resell-keystore.kts` I cannot yet... until I deactivate the existing Expo Play Console)

## Next Steps

Must deactivate existing cloud console stuff for Expo play store once we are ready to release. This should allow us to login again even on `release`

