### PR TITLE
Add ResellLoadingCard

### DIFF
--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
@@ -38,7 +38,7 @@ fun ResellLoadingCard(
             .widthIn(max = maxWidth)
             .fillMaxWidth()
             .clip(RoundedCornerShape(size = 8.dp))
-            .background(Color.White)
+            .background(color = Color.White)
             .border(width = 1.dp, color = Stroke, shape = RoundedCornerShape(8.dp))
     ) {
         Box(
@@ -54,22 +54,22 @@ fun ResellLoadingCard(
                 .padding(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            LoadingText(Modifier.weight(1f))
-            Spacer(Modifier.width(6.dp))
-            LoadingText(Modifier.width(45.dp))
+            LoadingText(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.width(6.dp))
+            LoadingText(modifier = Modifier.width(45.dp))
         }
     }
 }
 
 @Composable
 private fun LoadingText(modifier: Modifier) {
-    Column(
+    Box(
         modifier = modifier
             .height(17.dp)
             .clip(RoundedCornerShape(size = 100.dp))
             .shimmer()
             .border(width = 3.dp, color = Color.White, shape = RoundedCornerShape(100.dp))
-    ) { }
+    )
 }
 
 @Preview

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
@@ -2,14 +2,14 @@ package com.cornellappdev.resell.android.ui.components.global
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -19,11 +19,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
+import com.cornellappdev.resell.android.ui.theme.ResellPreview
 import com.cornellappdev.resell.android.ui.theme.Stroke
-import com.cornellappdev.resell.android.ui.theme.Wash
 import com.cornellappdev.resell.android.util.shimmer
 
 @Composable
@@ -32,65 +31,55 @@ fun ResellLoadingCard(
     small: Boolean
 ) {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
-    val width = 0.5f * screenWidth
-    val scale = 1.0 / 173.0 * width
-    val height = if (small) 144.73 * scale else 246.4 * scale
-    val contentHeight = if(small) 111.73*scale else 213.4 * scale
+    val maxWidth = 0.5f * screenWidth
+    val contentHeight = if (small) 112.dp else 213.dp
     Column(
         modifier = modifier
-            .widthIn(max = width)
+            .widthIn(max = maxWidth)
             .fillMaxWidth()
             .clip(RoundedCornerShape(size = 8.dp))
             .background(Color.White)
             .border(width = 1.dp, color = Stroke, shape = RoundedCornerShape(8.dp))
-            .heightIn(max = height)
     ) {
         Box(
-            modifier = modifier
-                .heightIn(max = contentHeight)
-                .fillMaxSize()
-                .background(
-                    Wash
-                )
-//                .shimmer()
+            modifier = Modifier
+                .height(contentHeight)
+                .fillMaxWidth()
+                .shimmer()
         )
 
         Row(
             modifier = Modifier
-                .fillMaxSize(),
-            horizontalArrangement = Arrangement.SpaceEvenly,
+                .fillMaxWidth()
+                .padding(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            LoadingText(106.0f, scale)
-            LoadingText(45.0f, scale)
+            LoadingText(Modifier.weight(1f))
+            Spacer(Modifier.width(6.dp))
+            LoadingText(Modifier.width(45.dp))
         }
     }
 }
 
 @Composable
-private fun LoadingText(width: Float, scale: Dp) {
+private fun LoadingText(modifier: Modifier) {
     Column(
-        modifier = Modifier
-            .widthIn(max = width * scale)
-            .heightIn(max = 17.0 * scale)
-            .fillMaxWidth()
+        modifier = modifier
+            .height(17.dp)
             .clip(RoundedCornerShape(size = 100.dp))
-            .background(Wash)
-//            .shimmer()
+            .shimmer()
             .border(width = 3.dp, color = Color.White, shape = RoundedCornerShape(100.dp))
-            .fillMaxHeight()
     ) { }
-
 }
 
 @Preview
 @Composable
-private fun PreviewResellSmallLoadingCard() {
+private fun PreviewResellSmallLoadingCard() = ResellPreview {
     ResellLoadingCard(modifier = Modifier, small = true)
 }
 
 @Preview
 @Composable
-private fun PreviewResellBigLoadingCard() {
+private fun PreviewResellBigLoadingCard() = ResellPreview {
     ResellLoadingCard(modifier = Modifier, small = false)
 }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
 import com.cornellappdev.resell.android.ui.theme.Stroke
 import com.cornellappdev.resell.android.ui.theme.Wash
+import com.cornellappdev.resell.android.util.shimmer
 
 @Composable
 fun ResellLoadingCard(
@@ -51,6 +52,7 @@ fun ResellLoadingCard(
                 .background(
                     Wash
                 )
+//                .shimmer()
         )
 
         Row(
@@ -74,6 +76,7 @@ private fun LoadingText(width: Float, scale: Dp) {
             .fillMaxWidth()
             .clip(RoundedCornerShape(size = 100.dp))
             .background(Wash)
+//            .shimmer()
             .border(width = 3.dp, color = Color.White, shape = RoundedCornerShape(100.dp))
             .fillMaxHeight()
     ) { }
@@ -82,12 +85,12 @@ private fun LoadingText(width: Float, scale: Dp) {
 
 @Preview
 @Composable
-fun PreviewResellSmallLoadingCard() {
+private fun PreviewResellSmallLoadingCard() {
     ResellLoadingCard(modifier = Modifier, small = true)
 }
 
 @Preview
 @Composable
-fun PreviewResellBigLoadingCard() {
+private fun PreviewResellBigLoadingCard() {
     ResellLoadingCard(modifier = Modifier, small = false)
 }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
@@ -75,11 +75,11 @@ private fun LoadingText(modifier: Modifier) {
 @Preview
 @Composable
 private fun PreviewResellSmallLoadingCard() = ResellPreview {
-    ResellLoadingCard(modifier = Modifier, small = true)
+    ResellLoadingCard(small = true, modifier = Modifier)
 }
 
 @Preview
 @Composable
 private fun PreviewResellBigLoadingCard() = ResellPreview {
-    ResellLoadingCard(modifier = Modifier, small = false)
+    ResellLoadingCard(small = false, modifier = Modifier)
 }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
@@ -1,0 +1,93 @@
+package com.cornellappdev.resell.android.ui.components.global
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.times
+import com.cornellappdev.resell.android.ui.theme.Stroke
+import com.cornellappdev.resell.android.ui.theme.Wash
+
+@Composable
+fun ResellLoadingCard(
+    modifier: Modifier = Modifier,
+    small: Boolean
+) {
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val width = 0.5f * screenWidth
+    val scale = 1.0 / 173.0 * width
+    val height = if (small) 144.73 * scale else 246.4 * scale
+    val contentHeight = if(small) 111.73*scale else 213.4 * scale
+    Column(
+        modifier = modifier
+            .widthIn(max = width)
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(size = 8.dp))
+            .background(Color.White)
+            .border(width = 1.dp, color = Stroke, shape = RoundedCornerShape(8.dp))
+            .heightIn(max = height)
+    ) {
+        Box(
+            modifier = modifier
+                .heightIn(max = contentHeight)
+                .fillMaxSize()
+                .background(
+                    Wash
+                )
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxSize(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            LoadingText(106.0f, scale)
+            LoadingText(45.0f, scale)
+        }
+    }
+}
+
+@Composable
+private fun LoadingText(width: Float, scale: Dp) {
+    Column(
+        modifier = Modifier
+            .widthIn(max = width * scale)
+            .heightIn(max = 17.0 * scale)
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(size = 100.dp))
+            .background(Wash)
+            .border(width = 3.dp, color = Color.White, shape = RoundedCornerShape(100.dp))
+            .fillMaxHeight()
+    ) { }
+
+}
+
+@Preview
+@Composable
+fun PreviewResellSmallLoadingCard() {
+    ResellLoadingCard(modifier = Modifier, small = true)
+}
+
+@Preview
+@Composable
+fun PreviewResellBigLoadingCard() {
+    ResellLoadingCard(modifier = Modifier, small = false)
+}

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingCard.kt
@@ -27,8 +27,8 @@ import com.cornellappdev.resell.android.util.shimmer
 
 @Composable
 fun ResellLoadingCard(
-    modifier: Modifier = Modifier,
-    small: Boolean
+    small: Boolean,
+    modifier: Modifier = Modifier
 ) {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
     val maxWidth = 0.5f * screenWidth


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->
<!-- Your title should be able to summarize what changes you’ve made in one sentence. For example: “Exclude staff from the check for follows”. For stacked PRs, please indicate clearly in the title where in the stack you are. For example: “[Eatery Refactor][4/5] Converted all files to MVP model” -->
## Overview
<!-- Summarize your changes here. -->
Created `ResellLoadingCard` component with previews.
<!-- Include details of what your changes actually are and how it is intended to work. -->
`ResellLoadingCard` is adapted from `ResellCard` to indicate that the home screen is loading. The size of the card can be toggled with the `small` argument.

[Figma link](https://www.figma.com/design/aLxCDVOinx5lB7mnkvMJ3G/resell-SP25?node-id=26243-40415&m=dev)
## Next Steps
<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

- Create a scrollable component populated by `ResellLoadingCard`
- Integrate the scrollable component to `HomeScreen`'s loading state
