### PR TITLE
Add ResellLoadingListingScroll

### DIFF
--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -1,37 +1,45 @@
 package com.cornellappdev.resell.android.ui.components.global
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.cornellappdev.resell.android.ui.theme.ResellPreview
+import kotlin.random.Random
 
 @Composable
 fun ResellLoadingListingScroll(
     modifier: Modifier = Modifier,
-    numCards: Int = 5,
+    numCards: Int = Int.MAX_VALUE,
     listState: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
 ) {
+    val randomList by remember {
+        mutableStateOf(List(50) { i ->
+            when (i) {
+                0 -> true
+                1 -> false
+                else -> Random.nextBoolean()
+            }
+        })
+    }
+
     LazyVerticalStaggeredGrid(
         columns = StaggeredGridCells.Fixed(2),
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier,
         state = listState,
         verticalItemSpacing = 24.dp,
         horizontalArrangement = Arrangement.spacedBy(20.dp)
     ) {
-        if (numCards >= 1) {
-            item {
-                ResellLoadingCard(small = true)
-            }
-            items(numCards - 1) {
-                ResellLoadingCard(small = false)
-            }
+        items(numCards) { idx ->
+            ResellLoadingCard(small = randomList[idx % randomList.size])
         }
     }
 }
@@ -39,7 +47,7 @@ fun ResellLoadingListingScroll(
 @Preview
 @Composable
 private fun PreviewHomeLoadingScroll() = ResellPreview {
-    ResellLoadingListingScroll(numCards = 5)
+    ResellLoadingListingScroll()
 }
 
 

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -1,0 +1,52 @@
+package com.cornellappdev.resell.android.ui.components.global
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.cornellappdev.resell.android.ui.theme.Padding
+
+@Composable
+fun ResellLoadingListingsScroll(
+    listState: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
+    modifier: Modifier = Modifier,
+    paddedTop: Dp = 0.dp,
+    header: @Composable () -> Unit = {},
+) {
+    LazyVerticalStaggeredGrid(
+        state = listState,
+        columns = StaggeredGridCells.Fixed(2),
+        contentPadding = PaddingValues(
+            bottom = 100.dp,
+            top = paddedTop,
+        ),
+        verticalItemSpacing = Padding.medium,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        item(span = StaggeredGridItemSpan.FullLine) {
+            header()
+        }
+        val cardModifier = Modifier.padding(horizontal = Padding.medium / 2f)
+        item {
+            ResellLoadingCard(cardModifier, small = true)
+        }
+        items(4) {
+            ResellLoadingCard(cardModifier, small = false)
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewResellLoadingListingsScroll() {
+    ResellLoadingListingsScroll()
+}

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -1,53 +1,52 @@
 package com.cornellappdev.resell.android.ui.components.global
 
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
-import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.cornellappdev.resell.android.ui.theme.Padding
 import com.cornellappdev.resell.android.ui.theme.ResellPreview
 
 @Composable
 fun ResellLoadingListingsScroll(
     modifier: Modifier = Modifier,
+    numCards: Int = 5,
     listState: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
-    paddedTop: Dp = 0.dp,
-    header: @Composable () -> Unit = {},
 ) {
     LazyVerticalStaggeredGrid(
-        state = listState,
         columns = StaggeredGridCells.Fixed(2),
-        contentPadding = PaddingValues(
-            bottom = 100.dp,
-            top = paddedTop,
-        ),
-        verticalItemSpacing = Padding.medium,
         modifier = modifier.fillMaxWidth(),
+        state = listState,
+        verticalItemSpacing = 24.dp,
+        horizontalArrangement = Arrangement.spacedBy(20.dp)
     ) {
-        item(span = StaggeredGridItemSpan.FullLine) {
-            header()
+        if (numCards >= 1) {
+            item {
+                ResellLoadingCard(small = true)
+            }
         }
-        val cardModifier = Modifier.padding(horizontal = Padding.medium / 2f)
-        item {
-            ResellLoadingCard(cardModifier, small = true)
-        }
-        items(4) {
-            ResellLoadingCard(cardModifier, small = false)
+        if (numCards >= 1) {
+            items(numCards - 1) {
+                ResellLoadingCard(small = false)
+            }
         }
     }
 }
 
 @Preview
 @Composable
-fun PreviewResellLoadingListingsScroll() = ResellPreview {
-    ResellLoadingListingsScroll()
+private fun PreviewHomeLoadingScroll() = ResellPreview {
+    ResellLoadingListingsScroll(numCards = 5)
+}
+
+
+@Preview
+@Composable
+private fun PreviewSearchLoadingScroll() = ResellPreview {
+    ResellLoadingListingsScroll(numCards = 2)
 }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 import com.cornellappdev.resell.android.ui.theme.ResellPreview
 
 @Composable
-fun ResellLoadingListingsScroll(
+fun ResellLoadingListingScroll(
     modifier: Modifier = Modifier,
     numCards: Int = 5,
     listState: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
@@ -39,12 +39,12 @@ fun ResellLoadingListingsScroll(
 @Preview
 @Composable
 private fun PreviewHomeLoadingScroll() = ResellPreview {
-    ResellLoadingListingsScroll(numCards = 5)
+    ResellLoadingListingScroll(numCards = 5)
 }
 
 
 @Preview
 @Composable
 private fun PreviewSearchLoadingScroll() = ResellPreview {
-    ResellLoadingListingsScroll(numCards = 2)
+    ResellLoadingListingScroll(numCards = 2)
 }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -29,8 +29,6 @@ fun ResellLoadingListingsScroll(
             item {
                 ResellLoadingCard(small = true)
             }
-        }
-        if (numCards >= 1) {
             items(numCards - 1) {
                 ResellLoadingCard(small = false)
             }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -14,11 +14,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.cornellappdev.resell.android.ui.theme.Padding
+import com.cornellappdev.resell.android.ui.theme.ResellPreview
 
 @Composable
 fun ResellLoadingListingsScroll(
-    listState: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
     modifier: Modifier = Modifier,
+    listState: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
     paddedTop: Dp = 0.dp,
     header: @Composable () -> Unit = {},
 ) {
@@ -47,6 +48,6 @@ fun ResellLoadingListingsScroll(
 
 @Preview
 @Composable
-fun PreviewResellLoadingListingsScroll() {
+fun PreviewResellLoadingListingsScroll() = ResellPreview {
     ResellLoadingListingsScroll()
 }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
@@ -29,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.resell.android.R
 import com.cornellappdev.resell.android.model.classes.ResellApiState
 import com.cornellappdev.resell.android.ui.components.global.ResellListingsScroll
+import com.cornellappdev.resell.android.ui.components.global.ResellLoadingListingsScroll
 import com.cornellappdev.resell.android.ui.components.global.ResellTag
 import com.cornellappdev.resell.android.ui.theme.Padding
 import com.cornellappdev.resell.android.ui.theme.Primary
@@ -72,7 +73,9 @@ fun HomeScreen(
                 )
             }
 
-            is ResellApiState.Loading -> {}
+            is ResellApiState.Loading -> {
+                ResellLoadingListingsScroll()
+            }
 
             is ResellApiState.Error -> {}
         }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
@@ -29,7 +29,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.resell.android.R
 import com.cornellappdev.resell.android.model.classes.ResellApiState
 import com.cornellappdev.resell.android.ui.components.global.ResellListingsScroll
-import com.cornellappdev.resell.android.ui.components.global.ResellLoadingListingsScroll
 import com.cornellappdev.resell.android.ui.components.global.ResellTag
 import com.cornellappdev.resell.android.ui.theme.Padding
 import com.cornellappdev.resell.android.ui.theme.Primary
@@ -73,9 +72,7 @@ fun HomeScreen(
                 )
             }
 
-            is ResellApiState.Loading -> {
-                ResellLoadingListingsScroll()
-            }
+            is ResellApiState.Loading -> {}
 
             is ResellApiState.Error -> {}
         }


### PR DESCRIPTION
## Overview
<!-- Summarize your changes here. -->
Created `ResellLoadingListingScroll` component with previews based on [Figma](https://www.figma.com/design/aLxCDVOinx5lB7mnkvMJ3G/resell-SP25?node-id=26243-40417&m=dev) and `ResellListingScroll`. This component is a scrollable grid of `ResellLoadingCard`.

## Next Steps
- Integrate `ResellLoadingListingScroll` into `HomeScreen`'s loading state