### PR TITLE
Add ResellLoadingListingScroll to HomeScreen and SearchScreen

### DIFF
--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -14,13 +14,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.cornellappdev.resell.android.ui.theme.Padding
 import com.cornellappdev.resell.android.ui.theme.ResellPreview
+import kotlin.math.min
 import kotlin.random.Random
 
 @Composable
 fun ResellLoadingListingScroll(
     modifier: Modifier = Modifier,
+    // -1 to avoid overflow in the grid
     numCards: Int = Int.MAX_VALUE - 1,
     listState: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
+    header: @Composable () -> Unit = {},
 ) {
     val randomList by remember {
         mutableStateOf(List(50) { i ->
@@ -38,10 +41,10 @@ fun ResellLoadingListingScroll(
         state = listState,
         verticalItemSpacing = Padding.medium,
     ) {
-        // For consistency with ResellListingScroll
-        item(span = StaggeredGridItemSpan.FullLine) {}
+        item(span = StaggeredGridItemSpan.FullLine) { header() }
 
-        items(numCards) { idx ->
+        // LazyVerticalStaggeredGrid takes at most Int.MAX_VALUE items
+        items(min(numCards, Int.MAX_VALUE - 1)) { idx ->
             ResellLoadingCard(
                 small = randomList[idx % randomList.size],
                 modifier = Modifier.padding(horizontal = Padding.medium / 2f)

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -1,6 +1,6 @@
 package com.cornellappdev.resell.android.ui.components.global
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
@@ -11,7 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import com.cornellappdev.resell.android.ui.theme.Padding
 import com.cornellappdev.resell.android.ui.theme.ResellPreview
 import kotlin.random.Random
 
@@ -35,11 +35,13 @@ fun ResellLoadingListingScroll(
         columns = StaggeredGridCells.Fixed(2),
         modifier = modifier,
         state = listState,
-        verticalItemSpacing = 24.dp,
-        horizontalArrangement = Arrangement.spacedBy(20.dp)
+        verticalItemSpacing = Padding.medium,
     ) {
         items(numCards) { idx ->
-            ResellLoadingCard(small = randomList[idx % randomList.size])
+            ResellLoadingCard(
+                small = randomList[idx % randomList.size],
+                modifier = Modifier.padding(horizontal = Padding.medium / 2f)
+            )
         }
     }
 }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -44,7 +44,7 @@ fun ResellLoadingListingScroll(
         item(span = StaggeredGridItemSpan.FullLine) { header() }
 
         // LazyVerticalStaggeredGrid takes at most Int.MAX_VALUE items
-        items(min(numCards, Int.MAX_VALUE - 1)) { idx ->
+        items(numCards.coerceIn(0, Int.MAX_VALUE - 1)) { idx ->
             ResellLoadingCard(
                 small = randomList[idx % randomList.size],
                 modifier = Modifier.padding(horizontal = Padding.medium / 2f)

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.cornellappdev.resell.android.ui.theme.Padding
 import com.cornellappdev.resell.android.ui.theme.ResellPreview
-import kotlin.math.min
 import kotlin.random.Random
 
 @Composable

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/global/ResellLoadingListingScroll.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -18,7 +19,7 @@ import kotlin.random.Random
 @Composable
 fun ResellLoadingListingScroll(
     modifier: Modifier = Modifier,
-    numCards: Int = Int.MAX_VALUE,
+    numCards: Int = Int.MAX_VALUE - 1,
     listState: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
 ) {
     val randomList by remember {
@@ -37,6 +38,9 @@ fun ResellLoadingListingScroll(
         state = listState,
         verticalItemSpacing = Padding.medium,
     ) {
+        // For consistency with ResellListingScroll
+        item(span = StaggeredGridItemSpan.FullLine) {}
+
         items(numCards) { idx ->
             ResellLoadingCard(
                 small = randomList[idx % randomList.size],

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/main/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/main/SearchScreen.kt
@@ -24,6 +24,7 @@ import com.cornellappdev.resell.android.R
 import com.cornellappdev.resell.android.model.classes.Listing
 import com.cornellappdev.resell.android.model.classes.ResellApiResponse
 import com.cornellappdev.resell.android.ui.components.global.ResellListingsScroll
+import com.cornellappdev.resell.android.ui.components.global.ResellLoadingListingScroll
 import com.cornellappdev.resell.android.ui.components.global.ResellTextEntry
 import com.cornellappdev.resell.android.util.UIEvent
 import com.cornellappdev.resell.android.util.clickableNoIndication
@@ -74,7 +75,9 @@ fun SearchScreen(
             }
 
             is ResellApiResponse.Pending -> {
-
+                ResellLoadingListingScroll(
+                    modifier = Modifier.padding(top = 12.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/components/main/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/components/main/SearchScreen.kt
@@ -3,6 +3,7 @@ package com.cornellappdev.resell.android.ui.components.main
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -60,13 +61,12 @@ fun SearchScreen(
             placeholder = placeholder,
             focusRequester = focusRequester
         )
-
+        Spacer(modifier = Modifier.padding(vertical = 12.dp))
         when (listings) {
             is ResellApiResponse.Success -> {
                 ResellListingsScroll(
                     listings = listings.data,
-                    onListingPressed = onListingPressed,
-                    paddedTop = 12.dp
+                    onListingPressed = onListingPressed
                 )
             }
 
@@ -75,9 +75,7 @@ fun SearchScreen(
             }
 
             is ResellApiResponse.Pending -> {
-                ResellLoadingListingScroll(
-                    modifier = Modifier.padding(top = 12.dp)
-                )
+                ResellLoadingListingScroll()
             }
         }
     }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
@@ -75,7 +75,9 @@ fun HomeScreen(
             }
 
             is ResellApiState.Loading -> {
-                ResellLoadingListingScroll(modifier = Modifier.padding(horizontal = 6.dp))
+                ResellLoadingListingScroll(
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
 
             is ResellApiState.Error -> {}

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
@@ -74,9 +74,7 @@ fun HomeScreen(
             }
 
             is ResellApiState.Loading -> {
-                ResellLoadingListingScroll(
-                    modifier = Modifier.fillMaxWidth()
-                )
+                ResellLoadingListingScroll()
             }
 
             is ResellApiState.Error -> {}

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
@@ -29,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.resell.android.R
 import com.cornellappdev.resell.android.model.classes.ResellApiState
 import com.cornellappdev.resell.android.ui.components.global.ResellListingsScroll
+import com.cornellappdev.resell.android.ui.components.global.ResellLoadingListingScroll
 import com.cornellappdev.resell.android.ui.components.global.ResellTag
 import com.cornellappdev.resell.android.ui.theme.Padding
 import com.cornellappdev.resell.android.ui.theme.Primary
@@ -72,7 +73,9 @@ fun HomeScreen(
                 )
             }
 
-            is ResellApiState.Loading -> {}
+            is ResellApiState.Loading -> {
+                ResellLoadingListingScroll()
+            }
 
             is ResellApiState.Error -> {}
         }

--- a/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/screens/main/HomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -74,7 +75,7 @@ fun HomeScreen(
             }
 
             is ResellApiState.Loading -> {
-                ResellLoadingListingScroll()
+                ResellLoadingListingScroll(modifier = Modifier.padding(horizontal = 6.dp))
             }
 
             is ResellApiState.Error -> {}


### PR DESCRIPTION
## Overview
- Integrated `ResellLoadingListingScroll` to `HomeScreen` and `SearchScreen`'s loading/pending states.
- Fixed spacing for `ResellLoadingListingScroll` to match `ResellListingScroll`
- Based on [Figma](https://www.figma.com/design/aLxCDVOinx5lB7mnkvMJ3G/resell-SP25?node-id=26243-40415&m=dev)


## Demo

https://github.com/user-attachments/assets/5c5ab871-6556-4eb8-a11e-d76d441e7156

