### PR TITLE
Fix search screen empty query response

### DIFF
--- a/app/src/main/java/com/cornellappdev/resell/android/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/viewmodel/SearchViewModel.kt
@@ -24,7 +24,7 @@ abstract class SearchViewModel(
         SearchViewModel.SearchUiState>(
     initialUiState = SearchUiState(
         query = "",
-        listings = ResellApiResponse.Pending,
+        listings = ResellApiResponse.Success(listOf()),
         uid = null,
         username = ""
     )
@@ -52,10 +52,14 @@ abstract class SearchViewModel(
                 )
             }
             try {
-                val response = searchRepository.searchPostByUser(stateValue().uid, query)
-                // By this time, the query may have changed. If so, ignore.
-                if (stateValue().query == query) {
-                    applyMutation { copy(listings = ResellApiResponse.Success(response)) }
+                if (query == "") {
+                    applyMutation { copy(listings = ResellApiResponse.Success(listOf())) }
+                } else {
+                    val response = searchRepository.searchPostByUser(stateValue().uid, query)
+                    // By this time, the query may have changed. If so, ignore.
+                    if (stateValue().query == query) {
+                        applyMutation { copy(listings = ResellApiResponse.Success(response)) }
+                    }
                 }
             } catch (e: Exception) {
                 Log.e("SearchViewModel", e.toString())

--- a/app/src/main/java/com/cornellappdev/resell/android/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/viewmodel/SearchViewModel.kt
@@ -64,7 +64,6 @@ abstract class SearchViewModel(
                     applyMutation { copy(listings = ResellApiResponse.Error) }
                 }
             }
-
         }
     }
 


### PR DESCRIPTION
## Overview
<!-- Summarize your changes here. -->
Originally, the search screen showed a loading screen when the user entered it, and any empty query after some nonempty query would result in all listings being displayed. This change makes both cases show a blank screen.

## Related PRs or Issues
<!-- List related PRs against other branches/repositories. -->
Fixes #62 

## Screenshots
[Search Screen.webm](https://github.com/user-attachments/assets/f4dd61fc-0896-424f-946d-2c4e4fb474fb)
