### PR TITLE
Fix PostDetailsPage's Bookmark and WhichPage position

### DIFF
--- a/app/src/main/java/com/cornellappdev/resell/android/ui/screens/pdp/PostDetailPage.kt
+++ b/app/src/main/java/com/cornellappdev/resell/android/ui/screens/pdp/PostDetailPage.kt
@@ -327,16 +327,14 @@ private fun BottomSheetContent(
                 .defaultHorizontalPadding()
                 .onGloballyPositioned { layoutCoordinates ->
                     val textPosition = layoutCoordinates.positionInRoot().y
-                    val textHeight = layoutCoordinates.size.height
-
                     val screenHeightPx = with(density) { screenHeight.toPx() }
 
                     // Calculate distance from bottom in px and convert to dp
-                    val distanceFromBottomPx = screenHeightPx - (textPosition + textHeight)
+                    val distanceFromBottomPx = screenHeightPx - textPosition
                     val textDistanceFromBottom = with(density) { distanceFromBottomPx.toDp() }
 
                     // Tell the parent that the height has changed.
-                    onHeightChanged(textDistanceFromBottom + 170.dp)
+                    onHeightChanged(textDistanceFromBottom + 115.dp)
                 },
             verticalAlignment = Alignment.CenterVertically
         ) {


### PR DESCRIPTION
## Overview
<!-- Summarize your changes here. -->
Made the position of the bookmark button and the `WhichPage` ellipses no longer depend on text height so that they do not overlap with the BottomSheet when the title is long. 

## Related PRs or Issues
Fixes #61 
